### PR TITLE
Added support for numeric values

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -331,7 +331,10 @@ console.info(
                     	else if(complexSettings.includes(key))
                     	{
                     		value = (this.yaml) ? this.yaml.parse(value) : null;
-                    	}
+                      } else if(/^[-]?\d+(\.\d+)?(e-?\d+)?$/.test(value)) { // Special processing for numbers
+                        value = parseFloat(value);
+                      }
+                      
                     }                  
                 }
                               


### PR DESCRIPTION
I've added a special handling case for templated values that look like numbers: digits potentially preceded by a minus sign, possibly followed by a '.' and more digits, possibly followed by 'e' and more digits, and converted them to a float. I don't think this will cause any trouble, as there shouldn't be any cases where a card expects a string and can't deal with a number, but the reverse isn't true; the gauge card, for example, refuses to work with a templated value as it expects a number.

If there is a problematic case I have overlooked, a potential solution would be to implement a check for a pseudofunction, i.e. templated values matching `{{numeric(some_value)}}` get converted to floats.